### PR TITLE
Fix environment parameter prefix not working in production mode

### DIFF
--- a/learninghouse/core/settings.py
+++ b/learninghouse/core/settings.py
@@ -28,7 +28,7 @@ class ServiceSettings(BaseSettings):
 
     class Config:  # pylint: disable=too-few-public-methods
         validate_assignment = True
-        prefix = 'learninghouse_'
+        env_prefix = 'learninghouse_'
 
     @property
     def fastapi_kwargs(self) -> Dict[str, Any]:

--- a/learninghouse/service.py
+++ b/learninghouse/service.py
@@ -32,7 +32,7 @@ def run():
     logger.info(f'Running {settings.title} {versions.service}')
     logger.info(versions.libraries_versions)
     logger.info(f'Running in {settings.environment} mode')
-    logger.info(f'Listening on {settings.base_url}')
+    logger.info(f'Listening on {settings.host}:{settings.port}')
     logger.info(f'Configuration directory {settings.brains_directory}')
     logger.info(f'URL to OpenAPI file {settings.openapi_url}')
 


### PR DESCRIPTION
Signed-off-by: Johannes Ott <mail@johannes-ott.net>